### PR TITLE
Make the broker module configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,17 @@ or:
 /opt/statusengine/cakephp/app/Console/cake statusengine_legacy -w
 ```
 
+6. Load the broker module in naemon.cfg:
+```
+broker_module=/opt/statusengine/statusengine.o
+```
+
+If you want to specify a different path to the JSON config, add the path behind the module path, like so:
+```
+broker_module=/opt/statusengine/statusengine.o /some/other/config.json
+```
+
+
 Migrate to Statusengine
 --------------
 

--- a/etc/module.cfg
+++ b/etc/module.cfg
@@ -2,5 +2,5 @@ define module{
     module_name    statusengine
     path           /opt/statusengine/statusengine.o
     module_type    neb
-    ;args           some args
+    args           /etc/statusengine.json
 }

--- a/etc/statusengine.json
+++ b/etc/statusengine.json
@@ -1,0 +1,21 @@
+{
+	"process_host_status_data" = true,
+	"process_service_status_data" = true,
+	"process_process_data" = true,
+	"process_service_check_data" = true,
+	"process_host_check_data" = true,
+	"process_state_change_data" = true,
+	"process_log_data" = true,
+	"process_system_command_data" = true,
+	"process_comment_data" = true,
+	"process_external_command_data" = true,
+	"process_acknowledgement_data" = true,
+	"process_flapping_data" = true,
+	"process_downtime_data" = true,
+	"process_notification_data" = true,
+	"process_program_status_data" = true,
+	"process_contact_status_data" = true,
+	"process_contact_notification_data" = true,
+	"process_contact_notification_method_data" = true,
+	"process_event_handler_data" = true
+}

--- a/statusengine/src/Makefile
+++ b/statusengine/src/Makefile
@@ -2,11 +2,11 @@ all: bin/nagios/statusengine.o bin/naemon/statusengine.o
 
 bin/nagios/statusengine.o: statusengine.c
 	mkdir -p bin/nagios
-	LANG=C gcc -DNAGIOS -shared -o "$@" -fPIC  -Wall -Werror statusengine.c -luuid -levent -lgearman -ljson-c
+	LANG=C gcc -DNAGIOS -shared -o "$@" -fPIC -D_GNU_SOURCE -Wall -Werror statusengine.c -luuid -levent -lgearman -ljson-c
 
 bin/naemon/statusengine.o: statusengine.c
 	mkdir -p bin/naemon
-	LANG=C gcc -DNAEMON -shared -o "$@" -fPIC  -Wall -Werror statusengine.c -luuid -levent -lgearman -ljson-c
+	LANG=C gcc -DNAEMON -shared -o "$@" -fPIC -D_GNU_SOURCE -Wall -Werror statusengine.c -luuid -levent -lgearman -ljson-c
 
 clean:
 	rm -f statusengine.o

--- a/statusengine/src/statusengine.c
+++ b/statusengine/src/statusengine.c
@@ -70,7 +70,6 @@
 #error Please define either NAEMON or NAGIOS using -DNAEMON or -DNAGIOS command line options.
 #endif
 
-
 #ifdef NAEMON
 //Load default event broker stuff
 #include "naemon/naemon.h"
@@ -152,6 +151,20 @@ void logswitch(int level, char *message){
 }
 
 
+int get_setting(json_object *conf, const char *key){
+	json_object *setting;
+	if( conf == NULL ){
+		// Default when unconfigured: yes
+		return 1;
+	}
+	if( !json_object_object_get_ex(conf, key, &setting) ){
+		// Default when configured but this setting is missing: no
+		return 0;
+	}
+	return json_object_get_boolean(setting);
+}
+
+
 //Broker initialize function
 int nebmodule_init(int flags, char *args, nebmodule *handle){
 
@@ -174,28 +187,82 @@ int nebmodule_init(int flags, char *args, nebmodule *handle){
 	logswitch(NSLOG_INFO_MESSAGE, "[Statusengine] Contribute to Statusenigne at: https://github.com/nook24/statusengine");
 	logswitch(NSLOG_INFO_MESSAGE, "[Statusengine] Thanks for using Statusengine :-)");
 
+	//Try to read the config
+	json_object *conf = NULL;
+	char *conffile = "/etc/statusengine.json";
+	if( args != NULL && strlen(args) > 0 ){
+		conffile = args;
+	}
+	if( access(conffile, R_OK) != -1 ){
+		conf = json_object_from_file(conffile);
+	}
+	else{
+		char *buffer;
+		if( asprintf(&buffer, "Statusengine - cannot read config from '%s'", conffile) != -1 ){
+			logswitch(NSLOG_CONFIG_WARNING, buffer);
+			free(buffer);
+		}
+	}
+
 	//Register callbacks
 	logswitch(NSLOG_INFO_MESSAGE, "[Statusengine] Register callbacks");
-	neb_register_callback(NEBCALLBACK_HOST_STATUS_DATA,                 statusengine_module_handle, 0, statusengine_handle_data);
-	neb_register_callback(NEBCALLBACK_SERVICE_STATUS_DATA,              statusengine_module_handle, 0, statusengine_handle_data);
-	neb_register_callback(NEBCALLBACK_PROCESS_DATA,                     statusengine_module_handle, 0, statusengine_handle_data);
-	neb_register_callback(NEBCALLBACK_SERVICE_CHECK_DATA,               statusengine_module_handle, 0, statusengine_handle_data);
-	neb_register_callback(NEBCALLBACK_HOST_CHECK_DATA,                  statusengine_module_handle, 0, statusengine_handle_data);
-	neb_register_callback(NEBCALLBACK_STATE_CHANGE_DATA,                statusengine_module_handle, 0, statusengine_handle_data);
-	neb_register_callback(NEBCALLBACK_LOG_DATA,                         statusengine_module_handle, 0, statusengine_handle_data);
-	neb_register_callback(NEBCALLBACK_SYSTEM_COMMAND_DATA,              statusengine_module_handle, 0, statusengine_handle_data);
-	neb_register_callback(NEBCALLBACK_COMMENT_DATA,                     statusengine_module_handle, 0, statusengine_handle_data);
-	neb_register_callback(NEBCALLBACK_EXTERNAL_COMMAND_DATA,            statusengine_module_handle, 0, statusengine_handle_data);
-	neb_register_callback(NEBCALLBACK_ACKNOWLEDGEMENT_DATA,             statusengine_module_handle, 0, statusengine_handle_data);
-	neb_register_callback(NEBCALLBACK_FLAPPING_DATA,                    statusengine_module_handle, 0, statusengine_handle_data);
-	neb_register_callback(NEBCALLBACK_DOWNTIME_DATA,                    statusengine_module_handle, 0, statusengine_handle_data);
-	neb_register_callback(NEBCALLBACK_NOTIFICATION_DATA,                statusengine_module_handle, 0, statusengine_handle_data);
-	neb_register_callback(NEBCALLBACK_PROGRAM_STATUS_DATA,              statusengine_module_handle, 0, statusengine_handle_data);
-	neb_register_callback(NEBCALLBACK_CONTACT_STATUS_DATA,              statusengine_module_handle, 0, statusengine_handle_data);
-	neb_register_callback(NEBCALLBACK_CONTACT_NOTIFICATION_DATA,        statusengine_module_handle, 0, statusengine_handle_data);
-	neb_register_callback(NEBCALLBACK_CONTACT_NOTIFICATION_METHOD_DATA, statusengine_module_handle, 0, statusengine_handle_data);
-	neb_register_callback(NEBCALLBACK_EVENT_HANDLER_DATA,               statusengine_module_handle, 0, statusengine_handle_data);
-	
+	if( get_setting(conf, "process_host_status_data") ){
+		neb_register_callback(NEBCALLBACK_HOST_STATUS_DATA,                 statusengine_module_handle, 0, statusengine_handle_data);
+	}
+	if( get_setting(conf, "process_service_status_data") ){
+		neb_register_callback(NEBCALLBACK_SERVICE_STATUS_DATA,              statusengine_module_handle, 0, statusengine_handle_data);
+	}
+	if( get_setting(conf, "process_process_data") ){
+		neb_register_callback(NEBCALLBACK_PROCESS_DATA,                     statusengine_module_handle, 0, statusengine_handle_data);
+	}
+	if( get_setting(conf, "process_service_check_data") ){
+		neb_register_callback(NEBCALLBACK_SERVICE_CHECK_DATA,               statusengine_module_handle, 0, statusengine_handle_data);
+	}
+	if( get_setting(conf, "process_host_check_data") ){
+		neb_register_callback(NEBCALLBACK_HOST_CHECK_DATA,                  statusengine_module_handle, 0, statusengine_handle_data);
+	}
+	if( get_setting(conf, "process_state_change_data") ){
+		neb_register_callback(NEBCALLBACK_STATE_CHANGE_DATA,                statusengine_module_handle, 0, statusengine_handle_data);
+	}
+	if( get_setting(conf, "process_log_data") ){
+		neb_register_callback(NEBCALLBACK_LOG_DATA,                         statusengine_module_handle, 0, statusengine_handle_data);
+	}
+	if( get_setting(conf, "process_system_command_data") ){
+		neb_register_callback(NEBCALLBACK_SYSTEM_COMMAND_DATA,              statusengine_module_handle, 0, statusengine_handle_data);
+	}
+	if( get_setting(conf, "process_comment_data") ){
+		neb_register_callback(NEBCALLBACK_COMMENT_DATA,                     statusengine_module_handle, 0, statusengine_handle_data);
+	}
+	if( get_setting(conf, "process_external_command_data") ){
+		neb_register_callback(NEBCALLBACK_EXTERNAL_COMMAND_DATA,            statusengine_module_handle, 0, statusengine_handle_data);
+	}
+	if( get_setting(conf, "process_acknowledgement_data") ){
+		neb_register_callback(NEBCALLBACK_ACKNOWLEDGEMENT_DATA,             statusengine_module_handle, 0, statusengine_handle_data);
+	}
+	if( get_setting(conf, "process_flapping_data") ){
+		neb_register_callback(NEBCALLBACK_FLAPPING_DATA,                    statusengine_module_handle, 0, statusengine_handle_data);
+	}
+	if( get_setting(conf, "process_downtime_data") ){
+		neb_register_callback(NEBCALLBACK_DOWNTIME_DATA,                    statusengine_module_handle, 0, statusengine_handle_data);
+	}
+	if( get_setting(conf, "process_notification_data") ){
+		neb_register_callback(NEBCALLBACK_NOTIFICATION_DATA,                statusengine_module_handle, 0, statusengine_handle_data);
+	}
+	if( get_setting(conf, "process_program_status_data") ){
+		neb_register_callback(NEBCALLBACK_PROGRAM_STATUS_DATA,              statusengine_module_handle, 0, statusengine_handle_data);
+	}
+	if( get_setting(conf, "process_contact_status_data") ){
+		neb_register_callback(NEBCALLBACK_CONTACT_STATUS_DATA,              statusengine_module_handle, 0, statusengine_handle_data);
+	}
+	if( get_setting(conf, "process_contact_notification_data") ){
+		neb_register_callback(NEBCALLBACK_CONTACT_NOTIFICATION_DATA,        statusengine_module_handle, 0, statusengine_handle_data);
+	}
+	if( get_setting(conf, "process_contact_notification_method_data") ){
+		neb_register_callback(NEBCALLBACK_CONTACT_NOTIFICATION_METHOD_DATA, statusengine_module_handle, 0, statusengine_handle_data);
+	}
+	if( get_setting(conf, "process_event_handler_data") ){
+		neb_register_callback(NEBCALLBACK_EVENT_HANDLER_DATA,               statusengine_module_handle, 0, statusengine_handle_data);
+	}
 
 	//Create gearman client
 	if (gearman_client_create(&gman_client) == NULL){


### PR DESCRIPTION
Change the statusengine event broker module to be able to read a config file in JSON format and only bind to those events that are enabled in the config.

The change is backwards-compatible in such a way that if no config file could be read, all events are enabled.
