### PR TITLE
Add unique index for table nagios_hoststatus

### DIFF
--- a/cakephp/app/Plugin/Legacy/Config/Schema/legacy_schema_innodb.php
+++ b/cakephp/app/Plugin/Legacy/Config/Schema/legacy_schema_innodb.php
@@ -640,6 +640,7 @@ class LegacySchema extends CakeSchema {
 		'check_timeperiod_object_id' => array('type' => 'integer', 'null' => false, 'default' => '0', 'unsigned' => false),
 		'indexes' => array(
 			'PRIMARY' => array('column' => 'hoststatus_id', 'unique' => 1),
+			'object_id_instance_id' => array('column' => array('host_object_id', 'instance_id'), 'unique' => 1),
 			'hoststatus' => array('column' => array('host_object_id', 'current_state'), 'unique' => 0)
 		),
 		'tableParameters' => array('charset' => 'utf8', 'collate' => 'utf8_swedish_ci', 'engine' => 'InnoDB')


### PR DESCRIPTION
Add unique index for table nagios_hoststatus (similar to nagios_servicestatus) to avoid duplicate status entries for one host.