### PR TITLE
Some fixes and multiple gearmand server support

### DIFF
--- a/statusengine/src/Makefile
+++ b/statusengine/src/Makefile
@@ -14,4 +14,4 @@ bin/naemon/statusengine-1-0-5.o: statusengine.c
 	LANG=C gcc -DNAEMON105 -shared -o "$@" -fPIC  -Wall -Werror statusengine.c -luuid -levent -lgearman -ljson-c -lglib-2.0 -I/usr/include/glib-2.0 -I/usr/lib/x86_64-linux-gnu/glib-2.0/include -lglib-2.0
 
 clean:
-	rm -f statusengine.o
+	rm -f bin/nagios/statusengine.o bin/naemon/statusengine.o bin/naemon/statusengine-1-0-5.o

--- a/statusengine/src/statusengine.c
+++ b/statusengine/src/statusengine.c
@@ -249,7 +249,7 @@ int use_object_data = 1;
 int enable_ochp = 0;
 int enable_ocsp = 0;
 
-char* gearman_server_addr = "127.0.0.1";
+char* gearman_server = "127.0.0.1";
 
 int statusengine_process_config_var(char *arg);
 int statusengine_process_module_args(char *args);
@@ -309,7 +309,7 @@ int nebmodule_init(int flags, char *args, nebmodule *handle){
 		logswitch(NSLOG_INFO_MESSAGE, "[Statusengine] Memory allocation failure on client creation\n");
 	}
 
-	ret= gearman_client_add_server(&gman_client, gearman_server_addr, 4730);
+	ret= gearman_client_add_servers(&gman_client, gearman_server);
 	if (ret != GEARMAN_SUCCESS){
 		logswitch(NSLOG_INFO_MESSAGE, (char *)gearman_client_error(&gman_client));
 	}
@@ -448,8 +448,11 @@ int statusengine_process_config_var(char *arg) {
 	} else if (!strcmp(var, "use_object_data")) {
 		use_object_data = atoi(strdup(val));
 		logswitch(NSLOG_INFO_MESSAGE, "[Statusengine] start with enabled use_object_data");
-	} else if (!strcmp(var, "gearman_server_addr")) {
-		gearman_server_addr = strdup(val);
+	} else if (!strcmp(var, "gearman_server")) {
+		gearman_server = strdup(val);
+		logswitch(NSLOG_INFO_MESSAGE, "[Statusengine] Gearman server address changed");
+	} else if (!strcmp(var, "gearman_server_addr")) {	// fallback to old variable
+		gearman_server = strdup(val);
 		logswitch(NSLOG_INFO_MESSAGE, "[Statusengine] Gearman server address changed");
 	} else {
 		return ERROR;

--- a/statusengine/src/statusengine.c
+++ b/statusengine/src/statusengine.c
@@ -203,7 +203,7 @@ void logswitch(int level, char *message){
 #ifdef NAGIOS
 	write_to_all_logs(message, level);
 #endif
-#ifdef NAEMON
+#if defined NAEMON105 || defined NAEMON
 	nm_log(level, "%s", message);
 #endif
 }

--- a/statusengine/src/statusengine.c
+++ b/statusengine/src/statusengine.c
@@ -191,8 +191,6 @@ extern char *global_service_event_handler;
 gearman_return_t ret; //remove me!!!
 gearman_client_st gman_client;
 
-gearman_client_st gman_client_ochp;
-
 void *statusengine_module_handle = NULL;
 
 int statusengine_handle_data(int, void *);
@@ -314,18 +312,6 @@ int nebmodule_init(int flags, char *args, nebmodule *handle){
 	ret= gearman_client_add_server(&gman_client, gearman_server_addr, 4730);
 	if (ret != GEARMAN_SUCCESS){
 		logswitch(NSLOG_INFO_MESSAGE, (char *)gearman_client_error(&gman_client));
-	}
-	
-	if(enable_ochp || enable_ocsp){
-		//Create gearman client for ochp/ocsp
-		if (gearman_client_create(&gman_client_ochp) == NULL){
-			logswitch(NSLOG_INFO_MESSAGE, "[Statusengine] Memory allocation failure on client creation for OCHP/OCSP\n");
-		}
-
-		ret= gearman_client_add_server(&gman_client_ochp, gearman_server_addr, 4730);
-		if (ret != GEARMAN_SUCCESS){
-			logswitch(NSLOG_INFO_MESSAGE, (char *)gearman_client_error(&gman_client_ochp));
-		}
 	}
 
 	return 0;
@@ -827,9 +813,9 @@ int statusengine_handle_data(int event_type, void *data){
 					}
 					
 					if(enable_ocsp){
-						ret= gearman_client_do_background(&gman_client_ochp, "statusngin_ocsp", NULL, (void *)json_string, (size_t)strlen(json_string), NULL);
+						ret= gearman_client_do_background(&gman_client, "statusngin_ocsp", NULL, (void *)json_string, (size_t)strlen(json_string), NULL);
 						if (ret != GEARMAN_SUCCESS)
-							logswitch(NSLOG_INFO_MESSAGE, (char *)gearman_client_error(&gman_client_ochp));
+							logswitch(NSLOG_INFO_MESSAGE, (char *)gearman_client_error(&gman_client));
 					}
 
 					json_object_put(servicecheck_object);
@@ -900,9 +886,9 @@ int statusengine_handle_data(int event_type, void *data){
 					}
 					
 					if(enable_ochp){
-						ret= gearman_client_do_background(&gman_client_ochp, "statusngin_ochp", NULL, (void *)json_string, (size_t)strlen(json_string), NULL);
+						ret= gearman_client_do_background(&gman_client, "statusngin_ochp", NULL, (void *)json_string, (size_t)strlen(json_string), NULL);
 						if (ret != GEARMAN_SUCCESS)
-							logswitch(NSLOG_INFO_MESSAGE, (char *)gearman_client_error(&gman_client_ochp));
+							logswitch(NSLOG_INFO_MESSAGE, (char *)gearman_client_error(&gman_client));
 					}
 
 					json_object_put(hostcheck_object);

--- a/statusengine/src/statusengine.c
+++ b/statusengine/src/statusengine.c
@@ -154,7 +154,7 @@
 #include <json-c/json.h>
 #endif
 
-#ifdef NAEMON
+#if defined NAEMON105 || defined NAEMON
 #include <string.h>
 #endif
 
@@ -186,10 +186,8 @@ extern sched_info scheduling_info;
 extern char *global_host_event_handler;
 extern char *global_service_event_handler;
 
-
-
-gearman_return_t ret; //remove me!!!
 gearman_client_st gman_client;
+
 
 void *statusengine_module_handle = NULL;
 
@@ -271,10 +269,8 @@ int statusengine_create_client() {
 
 // send job to main gearman
 int statusengine_send_job(char * queue, char * data) {
-	gearman_return_t ret = OK;
-
 	// send job to gearman server
-	ret = gearman_client_do_background(&gman_client, queue, NULL, (void *)data, (size_t)strlen(data), NULL);
+	gearman_return_t ret = gearman_client_do_background(&gman_client, queue, NULL, (void *)data, (size_t)strlen(data), NULL);
 
 	// recreate client, otherwise gearman sigsegvs
 	if (ret != GEARMAN_SUCCESS) {


### PR DESCRIPTION
Fixes:
* If the gearmand server goes away (stop) and comes back online (start) the gearman_client doesn't crash. It doesn't segfault but it stops sending stuff to the queues
* This version recreates the gearman_client if an error occurs
* The logswitch method didn't logged anything when using naemon >= 1.0.5

Changes:
* the logswitch method accepts multiple arguments for sprintf like logging
* add_servers is now used instead of add_server: this way you can have failover gearmand server (comma seperated, not really useful but it works), but change the server port very easily
* the gearman_server_addr option has been renamed to gearman_server (the old will continue to work)
* the gearman_server option accepts multiple gearmand server (semicolon seperated) where the job needs to be duplicated. This very useful for satellite systems that report to multiple phpNSTA masters
* connection errors to gearmand won't spam the naemon.log anymore. connection errors are repeated every minute

Example: Change default server:

    gearman_server=localhost:4731

Example: Send duplicates to 2 gearmand:

    gearman_server=localhost:4730;localhost:4731

Example: have a failover gearmand:

    gearman_server=localhost:4731,localhost:4730

This also works combined (whatever):

    gearman_server=localhost:4731,localhost:4730;localhost:4733,localhost:4732
