### PR TITLE
Watchdog workers/childs, fix systemd-restart on crash by exception

### DIFF
--- a/cakephp/app/Config/core.php
+++ b/cakephp/app/Config/core.php
@@ -405,6 +405,7 @@ CakeLog::levels([
 CakeLog::config('default', array(
 	'engine' => 'Syslog',
 	'prefix' => 'statusengine',
+	'flag' => LOG_ODELAY | LOG_PID,
 	'types' => array('emergency', 'alert', 'critical', 'error', 'warning', 'notice', 'info'),
 ));
 

--- a/cakephp/app/Console/Command/StatusengineLegacyShell.php
+++ b/cakephp/app/Console/Command/StatusengineLegacyShell.php
@@ -3410,7 +3410,6 @@ class StatusengineLegacyShell extends AppShell{
 				$this->work = false;
 				break;
 		}
-		$this->bindWorkerSignalHandler();
 	}
 
 	/**

--- a/cakephp/app/Console/Command/StatusengineLegacyShell.php
+++ b/cakephp/app/Console/Command/StatusengineLegacyShell.php
@@ -3165,7 +3165,7 @@ class StatusengineLegacyShell extends AppShell{
 			$this->bindQueues = true;
 			$this->queues = $worker['queues'];
 			$this->work = false;
-			$this->bindChildSignalHandler();
+			$this->bindWorkerSignalHandler();
 			$this->waitForInstructions();
 		} else {
 			return $pid;
@@ -3323,9 +3323,8 @@ class StatusengineLegacyShell extends AppShell{
 				}
 
 				CakeLog::info('I will continue my work');
-				$this->childWork();
+				$this->workerLoop();
 			}
-
 
 			pcntl_signal_dispatch();
 			//Check if the parent process still exists
@@ -3337,13 +3336,13 @@ class StatusengineLegacyShell extends AppShell{
 		}
 	}
 
-	public function bindChildSignalHandler(){
-		pcntl_signal(SIGTERM, [$this, 'childSignalHandler']);
-		pcntl_signal(SIGUSR1, [$this, 'childSignalHandler']);
-		pcntl_signal(SIGUSR2, [$this, 'childSignalHandler']);
+	public function bindWorkerSignalHandler(){
+		pcntl_signal(SIGTERM, [$this, 'workerSignalHandler']);
+		pcntl_signal(SIGUSR1, [$this, 'workerSignalHandler']);
+		pcntl_signal(SIGUSR2, [$this, 'workerSignalHandler']);
 	}
 
-	public function childWork(){
+	public function workerLoop(){
 		while($this->work === true){
 			pcntl_signal_dispatch();
 			$this->worker->work();
@@ -3384,7 +3383,7 @@ class StatusengineLegacyShell extends AppShell{
 		}
 	}
 
-	public function childSignalHandler($signo){
+	public function workerSignalHandler($signo){
 		CakeLog::info('Recived signal: '.$signo);
 		switch($signo){
 			case SIGTERM:
@@ -3411,7 +3410,7 @@ class StatusengineLegacyShell extends AppShell{
 				$this->work = false;
 				break;
 		}
-		$this->bindChildSignalHandler();
+		$this->bindWorkerSignalHandler();
 	}
 
 	/**

--- a/etc/systemd/system/statusengine.service
+++ b/etc/systemd/system/statusengine.service
@@ -5,7 +5,7 @@ After=syslog.target network.target mysql.service gearman-job-server.service
 [Service]
 User=root
 Type=simple
-Restart=on-failure
+Restart=always
 ExecStart=/opt/statusengine/cakephp/app/Console/cake statusengine_legacy -w -q
 RestartSec=30
 

--- a/etc/systemd/system/statusengine.service
+++ b/etc/systemd/system/statusengine.service
@@ -6,7 +6,7 @@ After=syslog.target network.target mysql.service gearman-job-server.service
 User=root
 Type=simple
 Restart=on-failure
-ExecStart=/opt/statusengine/cakephp/app/Console/cake statusengine_legacy -w
+ExecStart=/opt/statusengine/cakephp/app/Console/cake statusengine_legacy -w -q
 RestartSec=30
 
 [Install]


### PR DESCRIPTION
This pull request takes care of multiple things

1) no restart on crash (php exception) by systemd

> When php throws an exception usually the returncode is 255. But when using set_exception_handler to handle internally the exception the exit code of cake.php script is always 0 even when crashes. This seems to be a cakephp related problem. If systemd restart mode is set to "always", systemd takes care on a crash (for example: when the database goes down)


2) watch workers and restart them when needed

> sometimes a worker can crash (database related stuff, exceptions or other external inputs). The main process should take care of this, handle SIGCHLD events and restart missing childs.

3) when started via systemd the logout gets duplicated

> per default statusengine_legacy logs per default to stdout and syslog. this duplicates the log in syslog (1x from systemd stdout, 1x statusengine syslog)